### PR TITLE
AWS security group rules should not specify -1 for protocols and to/from ports.

### DIFF
--- a/modules/autoscale_gwlb/main.tf
+++ b/modules/autoscale_gwlb/main.tf
@@ -18,35 +18,35 @@ resource "aws_security_group" "permissive_sg" {
 resource "aws_vpc_security_group_ingress_rule" "ingress_rule_ipv4" {
   security_group_id = aws_security_group.permissive_sg.id
   cidr_ipv4         = "0.0.0.0/0"
-        from_port    = 0
+        #from_port    = 0
   ip_protocol       = "-1"
-        to_port      = 0
+        #to_port      = 0
     }
 
 resource "aws_vpc_security_group_egress_rule" "egress_rule_ipv4" {
   security_group_id = aws_security_group.permissive_sg.id
   cidr_ipv4         = "0.0.0.0/0"
-    from_port = 0
+    #from_port = 0
   ip_protocol       = "-1"
-    to_port = 0
+    #to_port = 0
   }
 
 resource "aws_vpc_security_group_ingress_rule" "ingress_rule_ipv6" {
   count = var.enable_ipv6 ? 1 : 0
   security_group_id = aws_security_group.permissive_sg.id
   cidr_ipv6         = "::/0"
-  from_port         = 0
+  #from_port         = 0
   ip_protocol       = "-1"
-  to_port           = 0
+  #to_port           = 0
   }  
 
 resource "aws_vpc_security_group_egress_rule" "egress_rule_ipv6" {
   count = var.enable_ipv6 ? 1 : 0
   security_group_id = aws_security_group.permissive_sg.id
   cidr_ipv6         = "::/0"
-        from_port    = 0
+        #from_port    = 0
   ip_protocol       = "-1"
-        to_port      = 0
+        #to_port      = 0
 }
 
 resource "aws_launch_template" "asg_launch_template" {


### PR DESCRIPTION
AWS security group ingress and egress rules should not specify -1 for protocols and from/to ports at the same time. protocol -1 implies all ports. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule#ip_protocol-1

This causes a failure when creating the resource. It may also affect other resources and modules which use the same security group resource but I have only verified this instance.